### PR TITLE
snap: bump to upstream release 2.1.9

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: nats
-version: 2.1.7
+version: 2.1.9
 summary: A simple, secure and high performance open source messaging system
 description: |
   NATS.io is a simple, secure and high performance open source messaging system for cloud
@@ -18,9 +18,10 @@ parts:
     plugin: go
     go-importpath: github.com/nats-io/nats-server/v2
     source: https://github.com/nats-io/nats-server
-    source-tag: v2.1.7
+    source-tag: v2.1.9
     source-type: git
     build-snaps:
+    # Upstream still builds their releases with 1.14
     - go/1.14/stable
     override-build: |
       unset GOPATH


### PR DESCRIPTION
See https://github.com/nats-io/nats-server/releases/tag/v2.1.9 for a list of changes