### PR TITLE
If nats-config plug connected, get nats.cfg

### DIFF
--- a/getconfig/bin/getconfig
+++ b/getconfig/bin/getconfig
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+# Copyright 2021 Canonical Ltd.  All rights reserved.
+#
+. $SNAP/bin/functions.sh
+getconfig

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# Copyright 2021 Canonical Ltd.  All rights reserved.
+#
+
+# obtain nats.cfg from content share if nats-config is connected
+getconfig(){
+  if snapctl is-connected nats-config; then
+    while [ ! -f $SNAP/external/share/nats.cfg ]; do
+      sleep 1
+    done
+    if [ ! -d $SNAP_COMMON/server/ ]; then
+      mkdir $SNAP_COMMON/server/
+    fi
+    cp $SNAP/external/share/nats.cfg $SNAP_COMMON/server/nats.cfg
+  fi
+}

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -2,5 +2,7 @@
 #
 # Copyright 2020 Canonical Ltd.  All rights reserved.
 #
+snapctl stop --disable $SNAP_NAME
+. $SNAP/bin/functions.sh
+getconfig
 
-snapctl stop --disable ${SNAP_NAME}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: nats
-version: 2.1.9
+version: '2.1.9'
 summary: A simple, secure and high performance open source messaging system
 description: |
   NATS.io is a simple, secure and high performance open source messaging system for cloud
@@ -7,13 +7,26 @@ description: |
 confinement: strict
 grade: stable
 
+plugs:
+  nats-config:
+    interface: content
+    content: nats-cfg
+    target: $SNAP/external
+
 apps:
   server:
     daemon: simple
     command: bin/start-nats.sh
     plugs: [network-bind]
 
+  getconfig:
+    command: bin/getconfig
+
 parts:
+  getconfig:
+    plugin: dump
+    source: getconfig
+
   nats:
     plugin: go
     go-importpath: github.com/nats-io/nats-server/v2
@@ -37,5 +50,7 @@ parts:
     source: scripts
     organize:
       start-nats.sh: bin/start-nats.sh
+      functions.sh: bin/functions.sh
     stage:
     - bin/start-nats.sh
+    - bin/functions.sh


### PR DESCRIPTION
With this PR. the install hook obtains a $SNAP_COMMON/server/nats.cfg file from the nats-config content share plug, if it is connected. If it is not connected, the install hook does nothing new. 

This allows a brand for example to publish a snap that generates a nats.cfg file and provides it through a content slot, and the plug can be connected to the slot at the image level through the gadget. 

A working nats-config snap repo is here: https://github.com/knitzsche/nats-snap/tree/nats-config 

I built a uc20 image for the pi where the gadget autoconnects the nats-config interface, and I was able to start the server on first boot since it had the file.

The PR also  includes a getconfig app to get the config, just to make is easier for testing when the nats-config
interface is not previously connected (before snap install), and since the install hook only runs once on first install.  